### PR TITLE
Shebang `/usr/bin/env` instead of `/bin/env`

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 # global for error reporting
 ASDF_OSCALCLI_ERROR=""

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,3 +1,3 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 echo "0.1.1 0.2.0 0.3.0 0.3.1"


### PR DESCRIPTION
On my machine running macOS Monterey, `/bin/env` isn't present which causes ASDF to error out when interacting with the oscal-cli plugin.

In my limited research `/usr/bin/env` seems to be preferred nowadays for maximum portability.

I have tested my fork and have confirmed that it solves the issue for me.