### PR TITLE
Dynamically compute versions

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -21,9 +21,12 @@ get_oscalcli() {
 	local version=$1
 	local destdir=$2
 
-	if [[ $version == *"SNAPSHOT"* ]]; then
+	if [[ $version == *"-"* ]]; then
 		local base="https://oss.sonatype.org/content/repositories/snapshots/gov/nist/secauto/oscal/tools/oscal-cli/cli-core"
-		local url="$base/$version/cli-core-$version-oscal-cli.tar.bz2"		
+		IFS='-'
+		read -a version_parts <<< "${version}"
+		local url="$base/${version_parts[0]}-SNAPSHOT/cli-core-${version}-oscal-cli.tar.bz2"
+		unset IFS
 	else
 		local base="https://repo1.maven.org/maven2/gov/nist/secauto/oscal/tools/oscal-cli/cli-core"
 		local url="$base/$version/cli-core-$version-oscal-cli.tar.bz2"

--- a/bin/install
+++ b/bin/install
@@ -21,9 +21,13 @@ get_oscalcli() {
 	local version=$1
 	local destdir=$2
 
-	local major=$(echo $version | cut -d '.' -f 1)
-	local base="https://repo1.maven.org/maven2/gov/nist/secauto/oscal"
-	local url="$base/tools/oscal-cli/cli-core/$version/cli-core-$version-oscal-cli.tar.bz2"
+	if [[ $version == *"SNAPSHOT"* ]]; then
+		local base="https://oss.sonatype.org/content/repositories/snapshots/gov/nist/secauto/oscal/tools/oscal-cli/cli-core"
+		local url="$base/$version/cli-core-$version-oscal-cli.tar.bz2"		
+	else
+		local base="https://repo1.maven.org/maven2/gov/nist/secauto/oscal/tools/oscal-cli/cli-core"
+		local url="$base/$version/cli-core-$version-oscal-cli.tar.bz2"
+	fi
 
 	curl -fLC - --retry 3 --retry-delay 3 -o "$destdir/$version.tar.bz2" "$url"
 }

--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -1,0 +1,5 @@
+#!/bin/env bash
+
+releases=($(curl -L --silent 'https://repo1.maven.org/maven2/gov/nist/secauto/oscal/tools/oscal-cli/cli-core/maven-metadata.xml' | sed -En 's|<version>(.*)</version>|\1|p' | tr -d '\n'))
+versions=("${releases[@]}")
+echo ${versions[@]}

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,3 +1,7 @@
 #!/usr/bin/env bash
 
-echo "0.1.1 0.2.0 0.3.0 0.3.1 0.3.2"
+releases=($(curl -L --silent 'https://repo1.maven.org/maven2/gov/nist/secauto/oscal/tools/oscal-cli/cli-core/maven-metadata.xml' | sed -En 's|<version>(.*)</version>|\1|p' | tr -d '\n'))
+snapshots=($(curl -L --silent 'https://oss.sonatype.org/content/repositories/snapshots/gov/nist/secauto/oscal/tools/oscal-cli/cli-core/maven-metadata.xml' | sed -En 's|<version>(.*)</version>|\1|p' | tr -d '\n'))
+snapshot_builds=($(curl -L --silent 'https://oss.sonatype.org/content/repositories/snapshots/gov/nist/secauto/oscal/tools/oscal-cli/cli-core/0.3.4-SNAPSHOT/maven-metadata.xml' | sed -En 's|<value>(.*)</value>|\1|p' | tr -d '\n'))
+versions=("${releases[@]}" "${snapshot_builds[-1]}")
+echo ${versions[@]}


### PR DESCRIPTION
For latest snapshot build and full releases, compute version by looking Maven OSS Sonatype release and snapshot servers.

Auto-detect latest stable build, do not default to the latest snapshot build.